### PR TITLE
Refactor registry name generation to remove dashes and handle dashed environment names more clearly

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -28,6 +28,9 @@ var tags = {
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 
+// The container registry name must not contain dashes (-) specially the environment name as the service does not allow dashes in the name.
+var containerRegistryName = replace(toLower('${abbrs.containerRegistryRegistries}-${environmentName}-${resourceToken}'), '-', '')
+
 resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
   name: '${abbrs.resourcesResourceGroups}-${environmentName}-${resourceToken}'
   location: location
@@ -51,7 +54,7 @@ module registry './shared/registry.bicep' = {
     location: location
     tags: tags
     //no dashes (-) in the name as the service dont allow dashes in the name
-    name: '${abbrs.containerRegistryRegistries}${environmentName}${resourceToken}'
+    name: containerRegistryName
   }
   scope: rg
 }


### PR DESCRIPTION

This pull request introduces changes to the `infra/main.bicep` file to address naming constraints for container registries by ensuring that dashes (`-`) are removed from their names. The changes improve compliance with service requirements and simplify the naming logic.

### Changes to container registry naming:

* **Variable definition for container registry name**:
  - Added a new variable, `containerRegistryName`, which removes dashes (`-`) from the generated registry name using the `replace` function. This ensures that the container registry name complies with the service's restrictions.

* **Updated module to use the new variable**:
  - Replaced the inline name generation logic in the `registry` module with the newly defined `containerRegistryName` variable for consistency and to enforce the no-dash naming rule.